### PR TITLE
fix(server/api): use api.findGroupById for password check

### DIFF
--- a/server/api.lua
+++ b/server/api.lua
@@ -216,7 +216,7 @@ utils.exportHandler('AddMember', api.AddMember)
 ---@param password string
 ---@return boolean?
 function api.isPasswordCorrect(groupId, password)
-    local group = groups?[groupId]
+    local group = api.findGroupById(groupId)
 
     if not group then
         return lib.print.error('isPasswordCorrect was sent an invalid groupId :'..groupId)


### PR DESCRIPTION
## Description

api.isPasswordCorrect was using `groups?[groupId]` to retrieve the group instead of the proper `api.findGroupById(groupId)` call causing unpredictable issues.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code and checked all of its functionality.
- [x] My pull request fits the contribution guidelines & code conventions.
